### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the feature**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Expected behaviour**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,14 @@
+---
+name: Task
+about: Suggest an idea for this project
+title: "[TASK]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the task**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
We might be able to use these issue templates to make it easier to write consistent issues for the project

based on the following templates I used in Jira
[jira_issue_templates.pdf](https://github.com/ArchBacon/Lumina-Engine/files/15096323/jira_issue_templates.pdf)
