### PR TITLE
Moved engine to private directory to prevent users from gaining access

### DIFF
--- a/engine/source/private/core/engine.cpp
+++ b/engine/source/private/core/engine.cpp
@@ -1,4 +1,4 @@
-﻿#include "core/engine.hpp"
+﻿#include "engine.hpp"
 
 #include "core/fileio.hpp"
 #include "core/log.hpp"

--- a/engine/source/private/core/engine.hpp
+++ b/engine/source/private/core/engine.hpp
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-#include "types.hpp"
+#include "core/types.hpp"
 
 #include <memory>
 

--- a/engine/source/private/core/main.cpp
+++ b/engine/source/private/core/main.cpp
@@ -1,4 +1,4 @@
-#include "core/engine.hpp"
+#include "engine.hpp"
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Users shouldn't have access to the engine root when using the engine. To keep access correct, I moved the engine to the private directory